### PR TITLE
Update common_click drag timing. Remove pixel checking

### DIFF
--- a/scripts/common_click.inc
+++ b/scripts/common_click.inc
@@ -12,20 +12,14 @@
 -------------------------------------------------------------------------------
 
 function drag(sourceX, sourceY, destX, destY)
-  local timeout;
   if not sourceX or not sourceY or not destX or not destY then
     error("Incorrect number of arguments for drag()");
   end
-  if not timeout then
-    timeout = 500;
-  end
-  local spot = getWaitSpot(destX, destY);
-  srSetMousePos(sourceX, sourceY);
+  srSetMousePos(sourceX, sourceY);  
   srMouseDown(sourceX, sourceY, 0);
   srSetMousePos(destX, destY);
-  local result = waitForChange(spot, timeout);
+  lsSleep(60);
   srMouseUp(destX, destY, 0);
-  return result;
 end
 
 -------------------------------------------------------------------------------
@@ -80,7 +74,7 @@ function safeDrag(sourceX, sourceY, destX, destY)
     error("Incorrect number of arguments for safeDrag()");
   end
   safeBegin();
-  return drag(sourceX, sourceY, destX, destY, timeout);
+  drag(sourceX, sourceY, destX, destY, timeout);
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The pixel checking was only effectively adding a 500ms timeout to the drag since the pixels being checked were going to be the same color more often than not. Dragging a window in-game should not be an operation that fails. If it is, then there are larger problems!