### PR TITLE
Update common, kettle and thistle

### DIFF
--- a/scripts/common.inc
+++ b/scripts/common.inc
@@ -177,5 +177,6 @@ dofile("common_find.inc");
 dofile("common_window.inc");
 dofile("common_text.inc");
 dofile("common_gps.inc");
+dofile("common_time.inc");
 dofile("common_game_options.inc");
 dofile("constants.inc");

--- a/scripts/common_time.inc
+++ b/scripts/common_time.inc
@@ -1,0 +1,17 @@
+-----------------------------------------------------------
+-- convertTime(ms)
+--
+-- returns days:minutes:seconds based on ms
+----------------------------------------------------------
+function convertTime(ms)
+	local duration = math.floor(ms / 1000);
+	local hours = math.floor(duration / 60 / 60);
+	local minutes = math.floor((duration - hours * 60 * 60) / 60);
+	local seconds = duration - hours * 60 * 60 - minutes * 60;
+
+  if hours > 0 then
+    return string.format("%02dh %02dm %02ds",hours,minutes,seconds);
+  else
+    return string.format("%02dm %02ds",minutes,seconds);
+  end
+end

--- a/scripts/common_window.inc
+++ b/scripts/common_window.inc
@@ -79,6 +79,7 @@ function stashWindow(sourceX, sourceY, corner, bounds, offset)
   end
 
   safeDrag(sourceX, sourceY, dest[0], dest[1]);
+  lsSleep(click_delay);
   srSetMousePos(sourceX, sourceY);
   lsSleep(click_delay);
   return dest;
@@ -561,7 +562,7 @@ function windowManager(title, message, allowCascade, allowUIGap, varWidth, varHe
       local y = 0;
       x, y = srMousePos();
       openAndPin(x, y, 500);
-      stashWindow(x + 15, y + 30, BOTTOM_RIGHT);
+      stashWindow(x, y, BOTTOM_RIGHT);
     end
     if lsButtonText(10, lsScreenY - 30, 0, 100, 0xFFFFFFff, "Done") then
       done = true;

--- a/scripts/kettle_full.lua
+++ b/scripts/kettle_full.lua
@@ -115,12 +115,11 @@ function runKettles(num_loops, action)
 
     waitForKettles(message, action.stoked, i, num_loops);
     clickAllImages("kettle/take.png");
-    if i < num_loops then
-      sleepWithStatus(5000,"Take all Kettles Completed!\n\nPausing before next Pass, in case you want to End Script", nil, 0.7);
-    end
     if finish_up then
       sleepWithStatus(5000,"Finish up initiated ...\n\nYou have completed " .. i .. "/" .. num_loops .. " passes.", nil, 0.7);
       break;
+    elseif i < num_loops then
+      sleepWithStatus(5000,"Take all Kettles Completed!\n\nPausing before next Pass, in case you want to End Script", nil, 0.7);
     end
   end
 end
@@ -133,6 +132,7 @@ end
 function waitForKettles(message, stoked, passes, num_loops)
   local done = false;
   while not done do
+    local finish_up_message = "";
     if stoked then
       igniteAll();
     end
@@ -144,14 +144,18 @@ function waitForKettles(message, stoked, passes, num_loops)
         done = false;
       end
     end
-    if finish_up and not finish_up_message then
-      message = message .. "\n\nFinishing up, this will be last pass!";
-      finish_up_message = 1;
+    if finish_up then
+      finish_up_message = "\n\nFinishing up; this will be last pass!";
+    end
+    if passes < num_loops then
+      finish_up_allowed = 1;
+    else
+      finish_up_allowed = nil;
     end
     if passes > 1 then
-      sleepWithStatus(5000, message .. "\n\nPass Elapsed Time: " .. getElapsedTime(startTimePass) .. "\n\nTotal Elapsed Time: " .. getElapsedTime(startTime), nil, 0.7);
+      sleepWithStatus(5000, message .. finish_up_message .. "\n\nPass Elapsed Time: " .. getElapsedTime(startTimePass) .. "\n\nTotal Elapsed Time: " .. getElapsedTime(startTime), nil, 0.7);
     else
-      sleepWithStatus(5000, message .. "\n\nPass Elapsed Time: " .. getElapsedTime(startTimePass), nil, 0.7);
+      sleepWithStatus(5000, message .. finish_up_message .. "\n\nPass Elapsed Time: " .. getElapsedTime(startTimePass), nil, 0.7);
     end
   end
 end
@@ -242,12 +246,37 @@ function menuKettles()
     srReadScreen();
     local kettles = #(findAllImages("ThisIs.png"));
     local num_loops = promptNumber("How many passes ?", 10);
-    local message = "Making " .. selected.label .. " requires:\n";
+    local estimated_time = 0;
+    local message = "";
+    local message_multiple_pass = "";
     for i=1,#(selected.matLabels) do
-      message = message .. "  " .. selected.matCounts[i]*num_loops*kettles
-        .. " " .. selected.matLabels[i] .. "\n";
+    if num_loops > 1 then
+        if selected.matLabels[i] == "Water" then message = message .. "  *"; end
+          message = message .. "  " .. selected.matCounts[i]*num_loops*kettles .. " " .. selected.matLabels[i] .. " (" .. selected.matCounts[i]*kettles .. " per pass)\n";
+	else
+        if selected.matLabels[i] == "Water" then message = message .. "  *"; end
+          message = message .. "  " .. selected.matCounts[i]*num_loops*kettles .. " " .. selected.matLabels[i] .. "\n";
+	end
     end
-    message = message .. "\n\nNote: Jugs are refilled before each pass begins, if an available water source is available (water icon or pinned Water Barrel)\n\nTip: Did you know? If the macro breaks or you quit (before kettles are done), restarting macro will pick up where you left off at (even if kettles are idle)!";
+
+    -- ************************************************************
+    -- Optional Estimated Times for Kettle Projects. Add more with elseif statements
+    if selected.label == "Potash" then
+	estimated_time = 765; -- how many estimated seconds - 765s =  12m 45s
+    end
+    -- ************************************************************
+
+    if estimated_time > 0 then
+	estimated_time = estimated_time*1000; -- convert to ms
+	if num_loops > 1 then
+	  message = message .. "  About " .. convertTime(estimated_time*num_loops) .. "  (" .. convertTime(estimated_time) .. " per pass)\n";
+        message_multiple_pass = " You will only need enough jugs for ONE pass IF water source is available.";
+	else
+	  message = message .. "  About " .. convertTime(estimated_time) .. "\n";
+	end
+    end
+
+    message = message .. "\n* Jugs are refilled BEFORE each pass begins, if an available water source is available (water icon or pinned Water Barrel, Water Well, Aqueduct)." .. message_multiple_pass .. "\n\nPRO TIP:  If the macro breaks or you abort (before kettles are done); restarting macro will pick up where you left off at (regardless if kettles are still running or idle)!";
     askForWindow(message);
     runKettles(num_loops, selected);
   end
@@ -281,9 +310,15 @@ function statusScreen(message, color, allow_break, scale)
       lsPrint(10, 24, 0, 0.7, 0.7, 0xB0B0B0ff,
         "Hold Alt+Shift to pause this script.");
     end
-    if not finish_up then
-      if lsButtonText(lsScreenX - 110, lsScreenY - 60, z, 100, 0xFFFFFFff, "Finish up") then
-        finish_up = 1;
+    if finish_up_allowed then
+      if finish_up then
+    	  if lsButtonText(lsScreenX - 110, lsScreenY - 60, z, 100, 0x40ff40ff, "Cancel Finish Up") then
+	    finish_up = nil;
+	  end
+      else
+	  if lsButtonText(lsScreenX - 110, lsScreenY - 60, z, 100, 0xFFFFFFff, "Finish up") then
+	    finish_up = 1;
+        end
       end
     end
     checkBreak();

--- a/scripts/thistle.lua
+++ b/scripts/thistle.lua
@@ -1017,16 +1017,3 @@ function explode(d,p)
   end
   return t
 end
-
-function convertTime(ms)
-	local duration = math.floor(ms / 1000);
-	local hours = math.floor(duration / 60 / 60);
-	local minutes = math.floor((duration - hours * 60 * 60) / 60);
-	local seconds = duration - hours * 60 * 60 - minutes * 60;
-
-  if hours > 0 then
-    return string.format("%02dh %02dm %02ds",hours,minutes,seconds);
-  else
-    return string.format("%02dm %02ds",minutes,seconds);
-  end
-end


### PR DESCRIPTION
- common.inc: Add dofile("common_time.inc");
- common_time.inc: New file with function convertTime(ms)
- common_window.inc: Remove the +15 x and +30 y settings. I'm not sure why this was done. When using function windowsManager() (Tap Alt over building to stash) the mouse returns to an offset; this is confusing. We should return to the exact mouse position when you tapped Alt button. This confirms the last building where you tapped Alt on.  These offsets is confusing (since mouse doesn't return to exact building location) and also makes you move mouse more to move to the next building for the next Tap Alt.
- thistle.lua - Removed function convertTime(ms) since it now is included in the new common_time.inc
- kettle_full.lua - Many tweaks.
Uses convertTime(ms) to display optional estimate kettle run times (currently Potash shows estimated times, more can be added).
You can now cancel Finish up button if clicked (you change your mind and no longer want to cancel).
Finish Up button will no longer appear if num_loops < passes
Extra 5s delay will no longer occur `sleepWithStatus(5000,"Take all Kettles Completed!\n\nPausing before next Pass, in case you want to End Script", nil, 0.7);` when not applicable (no more upcoming passes occurring).
Initial "Making" dialogue (that displays resources required will now also show Amounts per pass (when pass > 1).
Better description on initial dialogue about how you will only need enough jugs (for one pass) if you are near a water source.
