### PR TITLE
Add teppy_multiplier function - Some conversions

### DIFF
--- a/scripts/common_time.inc
+++ b/scripts/common_time.inc
@@ -1,17 +1,42 @@
 -----------------------------------------------------------
+-- Verified T11. teppy_multiplier can be found at https://catitd.com/time.asp?show or use test_ocr_lag_check.lua
+-- https://catitd.com/time.asp?show fetches game ratio from a reliable source: https://armeagle.atitd.org/tabtime.php ~ Thanks Brad!
+-- Math formula to determine teppy_multipler is: 1 + ( 1 - (ratio/3) )
+-- T11 multiplier averages between 0.893 - 0.915 - We'll use the higher end.
+
+  teppy_multiplier =  0.915;
+
+-----------------------------------------------------------
 -- convertTime(ms)
 --
 -- returns days:minutes:seconds based on ms
 ----------------------------------------------------------
 function convertTime(ms)
-	local duration = math.floor(ms / 1000);
-	local hours = math.floor(duration / 60 / 60);
-	local minutes = math.floor((duration - hours * 60 * 60) / 60);
-	local seconds = duration - hours * 60 * 60 - minutes * 60;
-
+  local duration = math.floor(ms / 1000);
+  local hours = math.floor(duration / 60 / 60);
+  local minutes = math.floor((duration - hours * 60 * 60) / 60);
+  local seconds = duration - hours * 60 * 60 - minutes * 60;
   if hours > 0 then
     return string.format("%02dh %02dm %02ds",hours,minutes,seconds);
   else
     return string.format("%02dm %02ds",minutes,seconds);
   end
+end
+
+-----------------------------------------------------------
+-- convertTeppyTime(ms)
+--
+-- returns adjusted ms based on teppy multipler
+-- Example: You want to return a ms value for sleepWithStatus() based on game seconds to complete a task.
+-- If you want to time drying linen, which takes 60 teppy seconds you use convertTeppyTime(60000) or convertTeppyTime(60)
+-- If ms < 1000 then we'll assume regular seconds was passed and multiply it by 1000.
+----------------------------------------------------------
+function convertTeppyTime(ms, extra_lag_secs)
+  if ms < 1000 then ms = ms * 1000 end
+    if extra_lag_secs == nil then
+      extra_lag_secs = 2000; -- Add default/minimum 2 seconds extra to adjust for potential lag.
+    elseif extra_lag_secs < 1000 and extra_lag_secs ~= 0 then
+      extra_lag_secs = extra_lag_secs * 1000;
+    end
+  return math.ceil( ( ms * teppy_multiplier ) + extra_lag_secs );
 end

--- a/scripts/paper_press.lua
+++ b/scripts/paper_press.lua
@@ -91,10 +91,10 @@ end
 function doPaper()
   if paperType == 1 then
     product = "Papyrus Paper"
-    productTimer = 75000
+    productTimer = convertTeppyTime(60);
   else
     product = "Wood Paper"
-    productTimer = 105000
+    productTimer = convertTeppyTime(90);
   end
 
 	for i=1, paper_passes do
@@ -163,7 +163,7 @@ function dryPressLining(product, lining)
       clickMax();
       lsSleep(100);
     end
-  sleepWithStatus(200000,"Waiting for " .. lining .. " to dry...", nil, 0.7);
+  sleepWithStatus(convertTeppyTime(180),"Waiting for " .. lining .. " to dry...", nil, 0.7);
   refreshWindows();
   clickAllText("Take");
   lsSleep(100);

--- a/scripts/thistle.lua
+++ b/scripts/thistle.lua
@@ -24,10 +24,8 @@ window_locs = {};
 
 -- How many real seconds it takes to complete a cycle
 -- This is only to display estimated times. It doesn't affect how the macro runs
--- Tale 11 is 6m 10s
-real_time_estimate = 370;
-game_time_ratio =  0.915;
-real_time_estimate = real_time_estimate * 1000;
+-- Tale 11 is ~6m 10s (370s)
+real_time_estimate = 370 * 1000; -- convert to ms
 
 ----------------------------------------
 
@@ -261,7 +259,8 @@ function config()
 
     tot_dung, tot_sp, tot_w = getRecipeTotals();
     y = y + 35;
-    lsPrintWrapped(10, y, z, lsScreenX - 20, 0.65, 0.65, 0xffecc7FF, "Real Time Required:      " .. convertTime(real_time_estimate*num_loops) .. "\nEgypt Time Required:    " .. convertTime(real_time_estimate / game_time_ratio * 3 * num_loops) .. "\nThistle Yield Expected:  " .. (5*num_loops*expected_gardens));
+    -- teppy_multiper is defined in common_time.inc
+    lsPrintWrapped(10, y, z, lsScreenX - 20, 0.65, 0.65, 0xffecc7FF, "Real Time Required:      " .. convertTime(real_time_estimate*num_loops) .. "\nEgypt Time Required:    " .. convertTime(real_time_estimate / teppy_multiplier * 3 * num_loops) .. "\nThistle Yield Expected:  " .. (5*num_loops*expected_gardens));
     y = y + 50;
     lsPrintWrapped(10, y, z, lsScreenX - 20, 0.65, 0.65, 0xffaa00FF, "Uses:  " .. tot_dung .. " Dung, " .. tot_sp .. " Saltpeter and " .. tot_w .. " Water.");
     y = y + 22;


### PR DESCRIPTION
**common_time.inc**
- Add standardized teppy_multipler value that can optionally be used across multiple scripts.
- Add new function convertTeppyTime(ms) - Converts ms or seconds to teppy time/seconds

----

**paper_press.lua**
- The current timers are hard coded to run much longer than needed. Use new function convertTeppyTime() for countdown instead (more accurate).

----

**thistle.lua**
- Removed hard coded game_time_ratio and change to teppy_multiplier which is now fetched from common_time.inc